### PR TITLE
feat: integrate signal-detect into status emission gating

### DIFF
--- a/runtime/include/picfw/runtime.h
+++ b/runtime/include/picfw/runtime.h
@@ -117,6 +117,9 @@ typedef struct picfw_runtime {
   picfw_bool_t arbitration_active;
   uint8_t arbitration_initiator;
 
+  /* --- Bus state (set by HAL before runtime_step) --- */
+  picfw_bool_t bus_busy; /* RB1 signal detect: TRUE = defer emission */
+
   /* --- Scan engine --- */
   uint32_t protocol_tick_ms;
   uint32_t protocol_deadline_ms;

--- a/runtime/src/pic16f15356_hal.c
+++ b/runtime/src/pic16f15356_hal.c
@@ -246,6 +246,10 @@ picfw_bool_t picfw_pic16f15356_mainline_service(picfw_pic16f15356_hal_t *hal, pi
     advanced_time = PICFW_TRUE;
   }
 
+  /* Always sample bus-busy signal so the field is current even on idle cycles.
+   * RB1 HIGH = another device transmitting = defer frame emission. */
+  runtime->bus_busy = picfw_pic16f15356_hal_signal_detect(hal);
+
   if (!delivered && !advanced_time) {
     return PICFW_FALSE;
   }

--- a/runtime/src/runtime.c
+++ b/runtime/src/runtime.c
@@ -1614,6 +1614,11 @@ static void picfw_runtime_service_periodic_status(picfw_runtime_t *runtime) {
   if (runtime->host_parser_active) {
     return;
   }
+  /* Defer emission when eBUS bus is busy (another device transmitting).
+   * Matches Ghidra line 3825: PORTB bit 1 HIGH gates output stage. */
+  if (runtime->bus_busy) {
+    return;
+  }
 
   for (emissions = 0u; emissions < PICFW_RUNTIME_STATUS_EMISSION_BUDGET;
        ++emissions) {
@@ -1684,6 +1689,7 @@ void picfw_runtime_init(picfw_runtime_t *runtime,
   runtime->host_parser_active = PICFW_FALSE;
   runtime->arbitration_active = PICFW_FALSE;
   runtime->arbitration_initiator = 0u;
+  runtime->bus_busy = PICFW_FALSE;
   picfw_runtime_seed_scan_state(runtime);
   runtime->status_snapshot_deadline_ms = 0u;
   runtime->status_variant_deadline_ms = 0u;

--- a/tests/test_runtime.c
+++ b/tests/test_runtime.c
@@ -2685,6 +2685,68 @@ static int test_protocol_dispatch_error_paths(void) {
   return errors;
 }
 
+static int test_signal_detect_gates_status_emission(void) {
+  const char *name = "signal_detect_gates_status";
+  picfw_pic16f15356_app_t app;
+  picfw_runtime_config_t config;
+  uint8_t tx[PICFW_RUNTIME_HOST_TX_CAP];
+  size_t tx_len;
+  int errors = 0;
+  uint16_t tick;
+
+  picfw_runtime_config_init_default(&config);
+  config.status_emit_enabled = PICFW_TRUE;
+  config.status_snapshot_period_ms = 100u;
+  config.status_variant_period_ms = 100u;
+  config.init_features = 0x01u;
+  picfw_pic16f15356_app_init(&app, &config);
+
+  /* Send INIT to reach LIVE_READY state */
+  picfw_pic16f15356_app_isr_host_rx(&app, 0xC0u); /* INIT byte1 */
+  picfw_pic16f15356_app_isr_host_rx(&app, 0x81u); /* INIT byte2 (cmd=0, data=1) */
+  /* Advance one scheduler tick to process INIT */
+  for (tick = 0u; tick <= PICFW_PIC16F15356_TMR0_ISR_DIVIDER; ++tick) {
+    picfw_pic16f15356_app_isr_tmr0(&app);
+  }
+  picfw_pic16f15356_app_mainline_service(&app);
+  /* Drain RESETTED response */
+  picfw_pic16f15356_app_drain_host_tx(&app, tx, sizeof(tx));
+
+  /* Advance time past the status deadline (2 scheduler ticks = 200ms) */
+  for (tick = 0u; tick <= PICFW_PIC16F15356_TMR0_ISR_DIVIDER; ++tick) {
+    picfw_pic16f15356_app_isr_tmr0(&app);
+  }
+  for (tick = 0u; tick <= PICFW_PIC16F15356_TMR0_ISR_DIVIDER; ++tick) {
+    picfw_pic16f15356_app_isr_tmr0(&app);
+  }
+
+  /* Test 1: Bus busy (RB1 HIGH) — status emission should be deferred */
+  app.hal.latches.portb_input = 0x02u; /* RB1=1 = bus busy */
+  picfw_pic16f15356_app_mainline_service(&app);
+  tx_len = picfw_pic16f15356_app_drain_host_tx(&app, tx, sizeof(tx));
+  errors += expect_true(name, tx_len == 0u,
+                        "no status frame when bus busy");
+
+  /* Test 2: Bus idle (RB1 LOW) — status emission should proceed */
+  app.hal.latches.portb_input = 0x00u; /* RB1=0 = bus idle */
+  picfw_pic16f15356_app_mainline_service(&app);
+  tx_len = picfw_pic16f15356_app_drain_host_tx(&app, tx, sizeof(tx));
+  errors += expect_true(name, tx_len > 0u,
+                        "status frame emitted when bus idle");
+
+  /* Test 3: bus_busy field is correctly set from signal detect */
+  app.hal.latches.portb_input = 0x02u;
+  picfw_pic16f15356_app_mainline_service(&app);
+  errors += expect_true(name, app.runtime.bus_busy == PICFW_TRUE,
+                        "bus_busy set when RB1 high");
+  app.hal.latches.portb_input = 0x00u;
+  picfw_pic16f15356_app_mainline_service(&app);
+  errors += expect_true(name, app.runtime.bus_busy == PICFW_FALSE,
+                        "bus_busy cleared when RB1 low");
+
+  return errors;
+}
+
 static int test_gpio_and_pin_model(void) {
   const char *name = "gpio_and_pin_model";
   picfw_pic16f15356_hal_t hal;
@@ -3000,6 +3062,9 @@ int main(void) {
     return 1;
   }
   if (test_gpio_and_pin_model() != 0) {
+    return 1;
+  }
+  if (test_signal_detect_gates_status_emission() != 0) {
     return 1;
   }
   printf("runtime tests passed\n");


### PR DESCRIPTION
## Summary
Wire `hal_signal_detect()` (RB1) into status emission gating. Bus busy = defer emission.

## Test plan
- [x] `make test` 4/4, `make check-all` 12/12, `test_checks.sh` 31/31
- [ ] 7-agent adversarial review

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)